### PR TITLE
Force foundry EVM version to Shangai

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -3,5 +3,6 @@ src = 'src'
 out = 'out'
 libs = ['lib']
 ffi = true
+evm_version = 'shanghai'
 remappings = ['ds-test/=lib/ds-test/src/']
 


### PR DESCRIPTION
This fixes the template as currently the default EVM verison is still Paris in foundry and this template is broken. Should be removed when foundry changes the default EVM version